### PR TITLE
Add moderation workflows and banned screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The root route now serves a minimal guild chat shell:
 - rich composer toolbar for bold, italic, inline code, code blocks, mentions, and slash commands
 - permission-aware transcript/composer UX for sending, reacting, deleting, and role-mention guidance
 - admins with emoji permission can upload/delete custom emoji and everyone can use them in a searchable full Unicode + custom reaction picker
+- moderation workflows for timeout, kick, and ban with member-sidebar actions plus a banned-account landing screen
 
 Login is rate limited, session metadata stores IP/user-agent, and channel rendering/posting now respects membership + permission checks.
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The root route now serves a minimal guild chat shell:
 - markdown rendering with code blocks and simple rich link cards in the transcript
 - rich composer toolbar for bold, italic, inline code, code blocks, mentions, and slash commands
 - permission-aware transcript/composer UX for sending, reacting, deleting, and role-mention guidance
+- admins with emoji permission can upload/delete custom emoji and everyone can use them in a searchable full Unicode + custom reaction picker
 
 Login is rate limited, session metadata stores IP/user-agent, and channel rendering/posting now respects membership + permission checks.
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -24,7 +24,7 @@ import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"
 import {hooks as colocatedHooks} from "phoenix-colocated/rfchat"
 import topbar from "../vendor/topbar"
-import {MessageListHook, RichComposerHook} from "./chat_hooks"
+import {MessageListHook, ReactionPickerHook, RichComposerHook} from "./chat_hooks"
 
 const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 const liveSocket = new LiveSocket("/live", Socket, {
@@ -33,6 +33,7 @@ const liveSocket = new LiveSocket("/live", Socket, {
   hooks: {
     RichComposerHook,
     MessageListHook,
+    ReactionPickerHook,
     ...colocatedHooks,
   },
 })

--- a/assets/js/chat_hooks.js
+++ b/assets/js/chat_hooks.js
@@ -5,6 +5,7 @@ import Mention from "@tiptap/extension-mention"
 import Link from "@tiptap/extension-link"
 import MarkdownIt from "markdown-it"
 import DOMPurify from "dompurify"
+import { CATEGORY_ORDER, CATEGORY_LABELS, filterEmojiCatalog } from "./emoji_catalog"
 
 const md = new MarkdownIt({
   html: false,
@@ -271,6 +272,120 @@ const MessageListHook = {
   },
 }
 
+const ReactionPickerHook = {
+  mounted() {
+    this.searchInput = this.el.querySelector("[data-reaction-picker-search]")
+    this.defaultsContainer = this.el.querySelector("[data-reaction-picker-defaults]")
+    this.categoriesContainer = this.el.querySelector("[data-reaction-picker-categories]")
+    this.customContainer = this.el.querySelector("[data-reaction-picker-custom]")
+    this.messageId = this.defaultsContainer?.dataset.messageId
+    this.activeCategory = null
+    this.query = ""
+
+    this.customEmojiIds = new Set(parseDatasetJson(this.el.dataset.customEmojis).map(item => item.id))
+
+    this.handleSearch = event => {
+      this.query = event.target.value || ""
+      this.renderCatalog()
+    }
+
+    this.handleCategoryClick = event => {
+      const button = event.target.closest("[data-reaction-picker-category]")
+      if(!button) return
+      event.preventDefault()
+
+      const nextCategory = button.dataset.reactionPickerCategory || null
+      this.activeCategory = this.activeCategory === nextCategory ? null : nextCategory
+      this.renderCatalog()
+    }
+
+    this.searchInput?.addEventListener("input", this.handleSearch)
+    this.categoriesContainer?.addEventListener("click", this.handleCategoryClick)
+    this.renderCatalog()
+    this.searchInput?.focus()
+  },
+
+  updated() {
+    this.customEmojiIds = new Set(parseDatasetJson(this.el.dataset.customEmojis).map(item => item.id))
+    this.renderCatalog()
+  },
+
+  destroyed() {
+    this.searchInput?.removeEventListener("input", this.handleSearch)
+    this.categoriesContainer?.removeEventListener("click", this.handleCategoryClick)
+  },
+
+  renderCatalog() {
+    if(!this.defaultsContainer || !this.categoriesContainer || !this.messageId) return
+
+    const items = filterEmojiCatalog(this.query, this.activeCategory)
+    this.renderCategories(items)
+    this.renderDefaults(items)
+    this.filterCustomEmojis()
+  },
+
+  renderCategories(items) {
+    const availableCategories = new Set(items.map(item => item.category))
+
+    this.categoriesContainer.innerHTML = ""
+
+    CATEGORY_ORDER.forEach(categoryId => {
+      if(this.query && !availableCategories.has(categoryId)) return
+
+      const button = document.createElement("button")
+      button.type = "button"
+      button.dataset.reactionPickerCategory = categoryId
+      button.className = [
+        "rounded-full border px-2 py-1 text-[10px] font-semibold transition",
+        this.activeCategory === categoryId
+          ? "border-violet-400/60 bg-violet-500/20 text-violet-100"
+          : "border-white/10 bg-black/10 text-zinc-400 hover:border-white/20 hover:text-zinc-200",
+      ].join(" ")
+      button.textContent = CATEGORY_LABELS[categoryId] || categoryId
+      this.categoriesContainer.appendChild(button)
+    })
+  },
+
+  renderDefaults(items) {
+    this.defaultsContainer.innerHTML = ""
+
+    if(items.length === 0) {
+      const empty = document.createElement("p")
+      empty.className = "col-span-6 rounded-xl border border-dashed border-white/8 bg-black/10 px-3 py-4 text-center text-xs text-zinc-500"
+      empty.textContent = "No default emojis match that search."
+      this.defaultsContainer.appendChild(empty)
+      return
+    }
+
+    items.forEach(entry => {
+      const button = document.createElement("button")
+      button.type = "button"
+      button.setAttribute("phx-click", "toggle_reaction")
+      button.setAttribute("phx-value-id", this.messageId)
+      button.setAttribute("phx-value-emoji", entry.emoji)
+      button.id = `reaction-picker-default-${this.messageId}-${entry.unified}`
+      button.className = "flex h-10 items-center justify-center rounded-xl border border-white/8 bg-black/10 text-lg transition hover:border-white/20 hover:bg-white/6"
+      button.title = entry.name
+      button.setAttribute("aria-label", entry.name)
+      button.textContent = entry.emoji
+      this.defaultsContainer.appendChild(button)
+    })
+  },
+
+  filterCustomEmojis() {
+    if(!this.customContainer) return
+
+    const normalizedQuery = this.query.trim().toLowerCase()
+
+    this.customContainer.querySelectorAll("[data-custom-emoji-id]").forEach(node => {
+      const name = (node.dataset.customEmojiName || "").toLowerCase()
+      const shortcode = (node.dataset.customEmojiShortcode || "").toLowerCase()
+      const visible = normalizedQuery === "" || name.includes(normalizedQuery) || shortcode.includes(normalizedQuery)
+      node.classList.toggle("hidden", !visible)
+    })
+  },
+}
+
 function buildSuggestion({ char, items, startOfLine = false }) {
   return {
     char,
@@ -531,4 +646,4 @@ function enhanceEmbeds(container) {
   })
 }
 
-export { MessageListHook, RichComposerHook }
+export { MessageListHook, ReactionPickerHook, RichComposerHook }

--- a/assets/js/emoji_catalog.js
+++ b/assets/js/emoji_catalog.js
@@ -1,0 +1,87 @@
+import emojiMartData from "@emoji-mart/data"
+
+const CATEGORY_ORDER = ["people", "nature", "foods", "activity", "places", "objects", "symbols", "flags"]
+
+const CATEGORY_LABELS = {
+  people: "Smileys & People",
+  nature: "Animals & Nature",
+  foods: "Food & Drink",
+  activity: "Activities",
+  places: "Travel & Places",
+  objects: "Objects",
+  symbols: "Symbols",
+  flags: "Flags",
+}
+
+const EMOJI_VERSION = emojiMartData.meta?.emojiVersion || 0
+
+const emojiById = emojiMartData.emojis || {}
+
+const emojiCatalog = CATEGORY_ORDER.flatMap(categoryId => {
+  const category = emojiMartData.categories.find(item => item.id === categoryId)
+  if(!category) return []
+
+  return category.emojis.flatMap(emojiId => buildEmojiEntries(emojiById[emojiId], categoryId))
+})
+
+function buildEmojiEntries(emoji, categoryId) {
+  if(!emoji || !emoji.skins?.length) return []
+
+  return emoji.skins
+    .filter(skin => skin.native)
+    .map((skin, index) => ({
+      id: `${emoji.id}:${skin.unified}`,
+      emoji: skin.native,
+      native: skin.native,
+      name: variantName(emoji.name, index),
+      shortcodes: [emoji.id, ...(emoji.keywords || [])],
+      keywords: emoji.keywords || [],
+      category: categoryId,
+      categoryLabel: CATEGORY_LABELS[categoryId] || categoryId,
+      version: emoji.version || EMOJI_VERSION,
+      skinTone: index,
+      unified: skin.unified,
+    }))
+}
+
+function variantName(baseName, skinIndex) {
+  if(skinIndex === 0) return baseName
+
+  return `${baseName}: ${skinToneLabel(skinIndex)}`
+}
+
+function skinToneLabel(index) {
+  switch(index) {
+    case 1:
+      return "light skin tone"
+    case 2:
+      return "medium-light skin tone"
+    case 3:
+      return "medium skin tone"
+    case 4:
+      return "medium-dark skin tone"
+    case 5:
+      return "dark skin tone"
+    default:
+      return "variant"
+  }
+}
+
+function filterEmojiCatalog(query, activeCategory = null, limit = 240) {
+  const normalizedQuery = query.trim().toLowerCase()
+
+  const filtered = emojiCatalog.filter(entry => {
+    if(activeCategory && entry.category !== activeCategory) return false
+    if(normalizedQuery === "") return true
+
+    const haystack = [entry.name, ...entry.shortcodes, ...entry.keywords, entry.native]
+      .join(" ")
+      .toLowerCase()
+
+    return haystack.includes(normalizedQuery)
+  })
+
+  return filtered.slice(0, limit)
+}
+
+export { CATEGORY_ORDER, CATEGORY_LABELS, emojiCatalog, filterEmojiCatalog }

--- a/assets/package.json
+++ b/assets/package.json
@@ -11,6 +11,7 @@
   "license": "Unlicense",
   "type": "commonjs",
   "dependencies": {
+    "@emoji-mart/data": "^1.2.1",
     "@tiptap/core": "^3.22.0",
     "@tiptap/extension-link": "^3.22.0",
     "@tiptap/extension-mention": "^3.22.0",

--- a/lib/rfchat/accounts.ex
+++ b/lib/rfchat/accounts.ex
@@ -22,6 +22,12 @@ defmodule Rfchat.Accounts do
 
   def get_user!(id), do: Repo.get!(User, id)
 
+  def get_user_with_membership!(id) do
+    User
+    |> Repo.get!(id)
+    |> Repo.preload([:membership, member_roles: :role])
+  end
+
   def list_members do
     User
     |> join(:inner, [user], membership in Membership, on: membership.user_id == user.id)
@@ -167,6 +173,28 @@ defmodule Rfchat.Accounts do
     }
   end
 
+  def membership_state(nil), do: :anonymous
+
+  def membership_state(%User{membership: nil}), do: :removed
+
+  def membership_state(%User{membership: membership}) do
+    cond do
+      is_nil(membership.deactivated_at) -> :active
+      membership_flag?(membership, "banned") -> :banned
+      true -> :removed
+    end
+  end
+
+  def banned?(%User{} = user), do: membership_state(user) == :banned
+  def removed?(%User{} = user), do: membership_state(user) == :removed
+
+  def timed_out?(%User{membership: %{timeout_until: timeout_until}})
+      when not is_nil(timeout_until) do
+    DateTime.compare(timeout_until, DateTime.utc_now()) == :gt
+  end
+
+  def timed_out?(%User{}), do: false
+
   def hash_token(token) when is_binary(token), do: :crypto.hash(:sha256, token)
 
   defp create_membership!(%User{} = user, now, owner_candidate?) do
@@ -217,6 +245,16 @@ defmodule Rfchat.Accounts do
       DateTime.diff(now, last_active_at, :second) <= 300 -> :online
       DateTime.diff(now, last_active_at, :second) <= 3_600 -> :recent
       true -> :offline
+    end
+  end
+
+  defp membership_flag?(membership, key) do
+    flags = membership.flags || %{}
+
+    case Map.get(flags, key) do
+      true -> true
+      "true" -> true
+      _ -> false
     end
   end
 end

--- a/lib/rfchat/chat.ex
+++ b/lib/rfchat/chat.ex
@@ -9,6 +9,8 @@ defmodule Rfchat.Chat do
   alias Rfchat.Chat.Authorization
   alias Rfchat.Chat.ChannelNotificationOverride
   alias Rfchat.Chat.ChannelMembership
+  alias Rfchat.Chat.Emoji
+  alias Rfchat.Chat.MediaAsset
   alias Rfchat.Chat.Message
   alias Rfchat.Chat.MessageRoleMention
   alias Rfchat.Chat.MessageUserMention
@@ -19,6 +21,11 @@ defmodule Rfchat.Chat do
   alias Rfchat.Repo
 
   @channel_events_topic "chat:channels"
+  @emoji_upload_dir "uploads/emojis"
+  @allowed_emoji_content_types ~w(image/png image/jpeg image/gif image/webp)
+  @default_reaction_emojis ["👍", "🔥", "❤️"]
+
+  def default_reaction_emojis, do: @default_reaction_emojis
 
   def list_channels do
     Channel
@@ -100,6 +107,76 @@ defmodule Rfchat.Chat do
       %{id: "code", label: "code", description: "Insert fenced code block"},
       %{id: "giphy", label: "giphy", description: "Insert a GIF-style embed request"}
     ]
+  end
+
+  def list_custom_emojis do
+    Emoji
+    |> order_by([emoji], asc: emoji.name, asc: emoji.inserted_at)
+    |> preload([:asset, :creator, :emoji_roles])
+    |> Repo.all()
+  end
+
+  def list_available_emojis(%User{} = user) do
+    user = Repo.preload(user, [:membership, member_roles: :role])
+    role_ids = MapSet.new(Enum.map(user.member_roles || [], & &1.role_id))
+
+    list_custom_emojis()
+    |> Enum.filter(&emoji_available_to_user?(&1, user, role_ids))
+  end
+
+  def get_emoji!(id) do
+    Emoji
+    |> preload([:asset, :creator, :emoji_roles])
+    |> Repo.get!(id)
+  end
+
+  def change_emoji(%Emoji{} = emoji, attrs \\ %{}) do
+    Emoji.changeset(emoji, attrs)
+  end
+
+  def create_custom_emoji_from_upload(attrs, %User{} = creator, upload) when is_map(attrs) do
+    attrs = normalize_emoji_attrs(attrs)
+
+    Repo.transaction(fn ->
+      with {:ok, asset} <- create_media_asset_from_upload(upload, creator),
+           {:ok, emoji} <-
+             %Emoji{creator_id: creator.id}
+             |> Emoji.changeset(Map.put(attrs, "asset_id", asset.id))
+             |> Repo.insert() do
+        Repo.preload(emoji, [:asset, :creator, :emoji_roles])
+      else
+        {:error, changeset} -> Repo.rollback(changeset)
+        {:error, reason, :upload} -> Repo.rollback({:upload, reason})
+      end
+    end)
+    |> case do
+      {:ok, emoji} -> {:ok, emoji}
+      {:error, {:upload, reason}} -> {:error, reason}
+      {:error, changeset} -> {:error, changeset}
+    end
+  end
+
+  def delete_custom_emoji(%Emoji{} = emoji) do
+    emoji = Repo.preload(emoji, [:asset])
+
+    Repo.transaction(fn ->
+      {:ok, deleted_emoji} = Repo.delete(emoji)
+
+      case deleted_emoji.asset do
+        %MediaAsset{} = asset ->
+          maybe_delete_asset_file(asset)
+          Repo.delete(asset)
+
+        _ ->
+          {:ok, nil}
+      end
+
+      deleted_emoji
+    end)
+    |> case do
+      {:ok, deleted_emoji} -> {:ok, deleted_emoji}
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   def list_channels_for_user(%User{} = user) do
@@ -363,7 +440,7 @@ defmodule Rfchat.Chat do
     |> where([message], is_nil(message.deleted_at))
     |> order_by([message], desc: message.inserted_at, desc: message.id)
     |> limit(^limit)
-    |> preload([:author, :reactions, reply_to: :author])
+    |> preload([:author, reactions: [emoji: :asset], reply_to: :author])
     |> Repo.all()
     |> Enum.reverse()
   end
@@ -389,7 +466,8 @@ defmodule Rfchat.Chat do
                |> Message.changeset(attrs)
                |> Repo.insert() do
           :ok = sync_message_mentions(message, attrs)
-          Repo.preload(message, [:author, :channel, :reactions, reply_to: :author])
+
+          Repo.preload(message, [:author, :channel, reactions: [emoji: :asset], reply_to: :author])
         else
           {:error, changeset} -> Repo.rollback(changeset)
         end
@@ -469,7 +547,7 @@ defmodule Rfchat.Chat do
 
   def get_message!(id) do
     Message
-    |> preload([:author, :channel, :reactions, reply_to: :author])
+    |> preload([:author, :channel, reactions: [emoji: :asset], reply_to: :author])
     |> Repo.get!(id)
   end
 
@@ -561,6 +639,43 @@ defmodule Rfchat.Chat do
     end
   end
 
+  def toggle_reaction(%Message{} = message, %User{} = user, %{"emoji_id" => emoji_id})
+      when is_binary(emoji_id) do
+    message = Repo.preload(message, channel: [:permission_overwrites])
+
+    with {:ok, emoji} <- fetch_available_emoji_for_user(emoji_id, user),
+         true <- can_add_reactions?(message.channel, user) do
+      case Repo.get_by(Reaction, message_id: message.id, user_id: user.id, emoji_id: emoji.id) do
+        nil ->
+          %Reaction{}
+          |> Reaction.changeset(%{
+            message_id: message.id,
+            user_id: user.id,
+            emoji_id: emoji.id
+          })
+          |> Repo.insert()
+          |> case do
+            {:ok, _reaction} ->
+              message = get_message!(message.id)
+              broadcast({:message_updated, message})
+              {:ok, message}
+
+            {:error, changeset} ->
+              {:error, changeset}
+          end
+
+        reaction ->
+          Repo.delete!(reaction)
+          message = get_message!(message.id)
+          broadcast({:message_updated, message})
+          {:ok, message}
+      end
+    else
+      false -> {:error, :forbidden}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   def mark_channel_read(%User{} = user, %Channel{} = channel, message \\ nil) do
     message = message || latest_message_for_channel(channel.id)
     now = DateTime.utc_now()
@@ -607,6 +722,16 @@ defmodule Rfchat.Chat do
     can_view_channel?(channel, user) and channel_permission?(channel, user, :mention_everyone)
   end
 
+  def can_manage_emojis_and_stickers?(%User{} = user) do
+    permissions =
+      user
+      |> Repo.preload([:membership, member_roles: :role])
+      |> Authorization.base_permissions(default_role())
+
+    Authorization.has_permission?(permissions, :manage_emojis_and_stickers) or
+      Authorization.has_permission?(permissions, :administrator)
+  end
+
   def message_count(channel_id) do
     Message
     |> where([message], message.channel_id == ^channel_id)
@@ -620,6 +745,9 @@ defmodule Rfchat.Chat do
   def default_role do
     Repo.get_by(Role, is_default: true)
   end
+
+  def asset_url(%MediaAsset{storage_key: storage_key}) when is_binary(storage_key),
+    do: "/#{storage_key}"
 
   defp normalize_message_attrs(attrs) do
     attrs =
@@ -642,6 +770,149 @@ defmodule Rfchat.Chat do
     attrs
     |> Map.put("metadata", normalized_metadata)
   end
+
+  defp normalize_emoji_attrs(attrs) do
+    attrs =
+      attrs
+      |> Enum.into(%{})
+      |> Enum.reduce(%{}, fn
+        {key, value}, acc when is_atom(key) -> Map.put(acc, Atom.to_string(key), value)
+        {key, value}, acc -> Map.put(acc, key, value)
+      end)
+
+    name = String.trim(Map.get(attrs, "name", ""))
+    shortcode = Map.get(attrs, "shortcode") |> blank_to_nil() |> normalize_shortcode(name)
+
+    attrs
+    |> Map.put("name", name)
+    |> Map.put("shortcode", shortcode)
+    |> Map.put_new("requires_colons", true)
+    |> Map.put_new("available", true)
+    |> Map.put_new("listed", true)
+  end
+
+  defp normalize_shortcode(nil, name), do: normalize_shortcode(name, name)
+
+  defp normalize_shortcode(value, _name) when is_binary(value) do
+    normalized =
+      value
+      |> String.downcase()
+      |> String.replace(~r/[^a-z0-9_+-]+/u, "_")
+      |> String.trim("_:")
+
+    if normalized == "", do: nil, else: ":#{normalized}:"
+  end
+
+  defp create_media_asset_from_upload(
+         %{path: path, client_name: client_name, client_type: client_type},
+         %User{} = creator
+       ) do
+    with :ok <- validate_emoji_upload(client_type),
+         {:ok, %{size: byte_size}} <- File.stat(path),
+         ext <- upload_extension(client_name, client_type),
+         storage_key <- Path.join(@emoji_upload_dir, "#{Ecto.UUID.generate()}#{ext}"),
+         destination <- asset_destination_path(storage_key),
+         :ok <- File.mkdir_p(Path.dirname(destination)),
+         :ok <- File.cp(path, destination),
+         {:ok, sha256} <- file_sha256(destination),
+         {:ok, asset} <-
+           %MediaAsset{}
+           |> MediaAsset.changeset(%{
+             uploader_id: creator.id,
+             kind: :emoji,
+             storage_key: storage_key,
+             original_filename: client_name,
+             content_type: client_type,
+             byte_size: byte_size,
+             sha256: sha256
+           })
+           |> Repo.insert() do
+      {:ok, asset}
+    else
+      {:error, reason} -> {:error, reason, :upload}
+    end
+  end
+
+  defp validate_emoji_upload(content_type) when content_type in @allowed_emoji_content_types,
+    do: :ok
+
+  defp validate_emoji_upload(_content_type), do: {:error, :invalid_upload_type}
+
+  defp upload_extension(filename, content_type) do
+    ext = filename |> Path.extname() |> String.downcase()
+
+    case ext do
+      ".png" -> ext
+      ".jpg" -> ext
+      ".jpeg" -> ext
+      ".gif" -> ext
+      ".webp" -> ext
+      _ -> extension_for_content_type(content_type)
+    end
+  end
+
+  defp extension_for_content_type("image/png"), do: ".png"
+  defp extension_for_content_type("image/jpeg"), do: ".jpg"
+  defp extension_for_content_type("image/gif"), do: ".gif"
+  defp extension_for_content_type("image/webp"), do: ".webp"
+  defp extension_for_content_type(_), do: ".bin"
+
+  defp asset_destination_path(storage_key) do
+    Application.app_dir(:rfchat, Path.join(["priv", "static", storage_key]))
+  end
+
+  defp file_sha256(path) do
+    case File.read(path) do
+      {:ok, binary} -> {:ok, :crypto.hash(:sha256, binary) |> Base.encode16(case: :lower)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp maybe_delete_asset_file(%MediaAsset{storage_key: storage_key})
+       when is_binary(storage_key) do
+    storage_key
+    |> asset_destination_path()
+    |> File.rm()
+
+    :ok
+  end
+
+  defp fetch_available_emoji_for_user(emoji_id, %User{} = user) do
+    emoji = get_emoji!(emoji_id)
+
+    if emoji_available_to_user?(emoji, Repo.preload(user, [:membership, member_roles: :role])) do
+      {:ok, emoji}
+    else
+      {:error, :forbidden}
+    end
+  rescue
+    Ecto.NoResultsError -> {:error, :invalid_emoji}
+  end
+
+  defp emoji_available_to_user?(%Emoji{} = emoji, %User{} = user, role_ids \\ nil) do
+    role_ids = role_ids || MapSet.new(Enum.map(user.member_roles || [], & &1.role_id))
+
+    cond do
+      not emoji.available ->
+        false
+
+      user.membership && user.membership.is_owner ->
+        true
+
+      can_manage_emojis_and_stickers?(user) ->
+        true
+
+      emoji.emoji_roles == [] ->
+        emoji.listed
+
+      true ->
+        emoji.listed and Enum.any?(emoji.emoji_roles, &MapSet.member?(role_ids, &1.role_id))
+    end
+  end
+
+  defp blank_to_nil(nil), do: nil
+  defp blank_to_nil(""), do: nil
+  defp blank_to_nil(value), do: value
 
   defp sync_message_mentions(%Message{id: message_id, body: body}, attrs) do
     clear_message_mentions(message_id)

--- a/lib/rfchat/chat.ex
+++ b/lib/rfchat/chat.ex
@@ -11,13 +11,16 @@ defmodule Rfchat.Chat do
   alias Rfchat.Chat.ChannelMembership
   alias Rfchat.Chat.Emoji
   alias Rfchat.Chat.MediaAsset
+  alias Rfchat.Chat.Membership
   alias Rfchat.Chat.Message
   alias Rfchat.Chat.MessageRoleMention
   alias Rfchat.Chat.MessageUserMention
+  alias Rfchat.Chat.ModerationCase
   alias Rfchat.Chat.Reaction
   alias Rfchat.Chat.Role
   alias Rfchat.Chat.User
   alias Rfchat.Chat.UserNotificationSetting
+  alias Rfchat.Chat.AuditLogEntry
   alias Rfchat.Repo
 
   @channel_events_topic "chat:channels"
@@ -455,6 +458,11 @@ defmodule Rfchat.Chat do
     Message.changeset(message, attrs)
   end
 
+  def change_moderation_action(attrs \\ %{}) do
+    {%{}, %{reason: :string, duration_minutes: :integer, action: :string}}
+    |> Ecto.Changeset.cast(attrs, [:reason, :duration_minutes, :action])
+  end
+
   def create_message(channel, author, attrs) do
     attrs = normalize_message_attrs(attrs)
     channel = Repo.preload(channel, [:permission_overwrites])
@@ -483,6 +491,61 @@ defmodule Rfchat.Chat do
     else
       {:error, reason} -> {:error, reason}
       {:error, changeset, :changeset} -> {:error, changeset}
+    end
+  end
+
+  def list_moderation_cases_for_user(user_id) do
+    ModerationCase
+    |> where([moderation_case], moderation_case.subject_user_id == ^user_id)
+    |> order_by([moderation_case], desc: moderation_case.inserted_at)
+    |> preload([:actor_user, :subject_user])
+    |> Repo.all()
+  end
+
+  def timeout_member(%User{} = actor, %User{} = subject, duration_minutes, reason \\ nil)
+      when is_integer(duration_minutes) and duration_minutes > 0 do
+    with :ok <- authorize_member_moderation(actor, subject, :moderate_members) do
+      timeout_until = DateTime.add(DateTime.utc_now(), duration_minutes * 60, :second)
+
+      Repo.transaction(fn ->
+        membership = Repo.preload(subject, [:membership]).membership || Repo.rollback(:not_member)
+
+        {:ok, membership} =
+          membership
+          |> Membership.changeset(%{timeout_until: timeout_until})
+          |> Repo.update()
+
+        moderation_case =
+          record_moderation_case!(actor, subject, :timeout, reason,
+            expires_at: timeout_until,
+            executed_at: DateTime.utc_now(),
+            details: %{"duration_minutes" => duration_minutes}
+          )
+
+        record_audit_log!(actor, subject, "timeout_member", reason, %{
+          "duration_minutes" => duration_minutes,
+          "timeout_until" => timeout_until
+        })
+
+        {Repo.preload(subject, [:membership, member_roles: :role])
+         |> Map.put(:membership, membership), moderation_case}
+      end)
+      |> case do
+        {:ok, {updated_subject, moderation_case}} -> {:ok, updated_subject, moderation_case}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  def kick_member(%User{} = actor, %User{} = subject, reason \\ nil) do
+    with :ok <- authorize_member_moderation(actor, subject, :kick_members) do
+      deactivate_member(actor, subject, :kick, reason, %{"kicked" => true})
+    end
+  end
+
+  def ban_member(%User{} = actor, %User{} = subject, reason \\ nil) do
+    with :ok <- authorize_member_moderation(actor, subject, :ban_members) do
+      deactivate_member(actor, subject, :ban, reason, %{"banned" => true, "ban_reason" => reason})
     end
   end
 
@@ -703,7 +766,8 @@ defmodule Rfchat.Chat do
   end
 
   def can_send_messages?(%Channel{} = channel, %User{} = user) do
-    channel_permission?(channel, user, :send_messages) and can_view_channel?(channel, user)
+    not timed_out?(user) and channel_permission?(channel, user, :send_messages) and
+      can_view_channel?(channel, user)
   end
 
   def can_view_channel?(%Channel{} = channel, %User{} = user) do
@@ -711,7 +775,8 @@ defmodule Rfchat.Chat do
   end
 
   def can_add_reactions?(%Channel{} = channel, %User{} = user) do
-    can_view_channel?(channel, user) and channel_permission?(channel, user, :add_reactions)
+    not timed_out?(user) and can_view_channel?(channel, user) and
+      channel_permission?(channel, user, :add_reactions)
   end
 
   def can_manage_messages?(%Channel{} = channel, %User{} = user) do
@@ -732,6 +797,13 @@ defmodule Rfchat.Chat do
       Authorization.has_permission?(permissions, :administrator)
   end
 
+  def timed_out?(%User{membership: %{timeout_until: timeout_until}})
+      when not is_nil(timeout_until) do
+    DateTime.compare(timeout_until, DateTime.utc_now()) == :gt
+  end
+
+  def timed_out?(%User{}), do: false
+
   def message_count(channel_id) do
     Message
     |> where([message], message.channel_id == ^channel_id)
@@ -744,6 +816,16 @@ defmodule Rfchat.Chat do
 
   def default_role do
     Repo.get_by(Role, is_default: true)
+  end
+
+  def moderation_permission?(%User{} = user, permission_name) do
+    permissions =
+      user
+      |> Repo.preload([:membership, member_roles: :role])
+      |> Authorization.base_permissions(default_role())
+
+    Authorization.has_permission?(permissions, permission_name) or
+      Authorization.has_permission?(permissions, :administrator)
   end
 
   def asset_url(%MediaAsset{storage_key: storage_key}) when is_binary(storage_key),
@@ -913,6 +995,84 @@ defmodule Rfchat.Chat do
   defp blank_to_nil(nil), do: nil
   defp blank_to_nil(""), do: nil
   defp blank_to_nil(value), do: value
+
+  defp deactivate_member(%User{} = actor, %User{} = subject, action_type, reason, extra_flags) do
+    Repo.transaction(fn ->
+      membership = Repo.preload(subject, [:membership]).membership || Repo.rollback(:not_member)
+      now = DateTime.utc_now()
+      flags = Map.merge(membership.flags || %{}, extra_flags)
+
+      {:ok, membership} =
+        membership
+        |> Membership.changeset(%{
+          deactivated_at: now,
+          timeout_until: nil,
+          flags: flags
+        })
+        |> Repo.update()
+
+      moderation_case =
+        record_moderation_case!(actor, subject, action_type, reason,
+          executed_at: now,
+          details: flags
+        )
+
+      record_audit_log!(actor, subject, "#{action_type}_member", reason, flags)
+
+      {Repo.preload(subject, [:membership, member_roles: :role])
+       |> Map.put(:membership, membership), moderation_case}
+    end)
+    |> case do
+      {:ok, {updated_subject, moderation_case}} -> {:ok, updated_subject, moderation_case}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp authorize_member_moderation(%User{} = actor, %User{} = subject, permission_name) do
+    actor = Repo.preload(actor, [:membership, member_roles: :role])
+    subject = Repo.preload(subject, [:membership, member_roles: :role])
+
+    cond do
+      actor.id == subject.id -> {:error, :forbidden}
+      subject.membership && subject.membership.is_owner -> {:error, :forbidden}
+      not moderation_permission?(actor, permission_name) -> {:error, :forbidden}
+      true -> :ok
+    end
+  end
+
+  defp record_moderation_case!(%User{} = actor, %User{} = subject, action_type, reason, attrs) do
+    %ModerationCase{}
+    |> ModerationCase.changeset(%{
+      case_number: next_case_number(),
+      action_type: action_type,
+      state: :executed,
+      actor_user_id: actor.id,
+      subject_user_id: subject.id,
+      reason: reason,
+      details: Keyword.get(attrs, :details, %{}),
+      expires_at: Keyword.get(attrs, :expires_at),
+      executed_at: Keyword.get(attrs, :executed_at)
+    })
+    |> Repo.insert!()
+  end
+
+  defp record_audit_log!(%User{} = actor, %User{} = subject, action_type, reason, metadata) do
+    %AuditLogEntry{}
+    |> AuditLogEntry.changeset(%{
+      action_type: action_type,
+      actor_user_id: actor.id,
+      subject_user_id: subject.id,
+      target_type: "user",
+      target_id: subject.id,
+      reason: reason,
+      metadata: metadata
+    })
+    |> Repo.insert!()
+  end
+
+  defp next_case_number do
+    (Repo.aggregate(ModerationCase, :max, :case_number) || 0) + 1
+  end
 
   defp sync_message_mentions(%Message{id: message_id, body: body}, attrs) do
     clear_message_mentions(message_id)

--- a/lib/rfchat/chat/emoji.ex
+++ b/lib/rfchat/chat/emoji.ex
@@ -27,7 +27,6 @@ defmodule Rfchat.Chat.Emoji do
       :name,
       :shortcode,
       :asset_id,
-      :creator_id,
       :requires_colons,
       :managed,
       :available,

--- a/lib/rfchat_web.ex
+++ b/lib/rfchat_web.ex
@@ -17,7 +17,7 @@ defmodule RfchatWeb do
   those modules here.
   """
 
-  def static_paths, do: ~w(assets fonts images favicon.ico robots.txt)
+  def static_paths, do: ~w(assets fonts images uploads favicon.ico robots.txt)
 
   def router do
     quote do

--- a/lib/rfchat_web/live/banned_live.ex
+++ b/lib/rfchat_web/live/banned_live.ex
@@ -1,0 +1,79 @@
+defmodule RfchatWeb.BannedLive do
+  use RfchatWeb, :live_view
+
+  alias Rfchat.Accounts
+
+  @impl true
+  def mount(_params, _session, socket) do
+    user = socket.assigns.current_user
+    membership = user.membership
+    flags = membership.flags || %{}
+
+    {:ok,
+     socket
+     |> assign(:page_title, "Banned")
+     |> assign(:ban_reason, Map.get(flags, "ban_reason"))
+     |> assign(:ban_at, membership.deactivated_at)
+     |> assign(:timed_out?, Accounts.timed_out?(user))}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} current_scope={@current_scope}>
+      <div class="min-h-screen bg-zinc-950 px-4 py-10 text-zinc-100 sm:px-6 lg:px-8">
+        <div class="mx-auto max-w-3xl rounded-[2rem] border border-rose-500/20 bg-zinc-900/80 p-8 shadow-[0_0_0_1px_rgba(255,255,255,0.03)] lg:p-10">
+          <p class="text-xs font-semibold uppercase tracking-[0.35em] text-rose-300">
+            RFChat moderation
+          </p>
+          <h1 class="mt-5 text-4xl font-semibold tracking-tight text-white lg:text-5xl">
+            This account is banned from this server.
+          </h1>
+          <p class="mt-5 max-w-2xl text-base leading-7 text-zinc-400">
+            Because each RFChat deployment is a single server, this ban blocks access to the server shell while still letting us explain what happened.
+          </p>
+
+          <div class="mt-8 grid gap-4 rounded-2xl border border-white/8 bg-black/20 p-5 sm:grid-cols-2">
+            <div>
+              <p class="text-[11px] font-bold uppercase tracking-[0.2em] text-zinc-500">Account</p>
+              <p class="mt-2 text-sm font-medium text-zinc-100">@{@current_user.username}</p>
+              <p class="mt-1 text-sm text-zinc-400">{@current_user.display_name}</p>
+            </div>
+
+            <div>
+              <p class="text-[11px] font-bold uppercase tracking-[0.2em] text-zinc-500">Banned at</p>
+              <p class="mt-2 text-sm text-zinc-100">
+                {if @ban_at,
+                  do: Calendar.strftime(@ban_at, "%b %-d, %Y at %H:%M UTC"),
+                  else: "Unavailable"}
+              </p>
+            </div>
+          </div>
+
+          <div class="mt-6 rounded-2xl border border-white/8 bg-black/20 p-5">
+            <p class="text-[11px] font-bold uppercase tracking-[0.2em] text-zinc-500">Reason</p>
+            <p class="mt-3 text-sm leading-7 text-zinc-200">
+              {if is_binary(@ban_reason) and String.trim(@ban_reason) != "",
+                do: @ban_reason,
+                else: "No public reason was provided."}
+            </p>
+          </div>
+
+          <div class="mt-6 flex flex-wrap items-center gap-3">
+            <.link
+              navigate={~p"/logout"}
+              method="delete"
+              class="inline-flex items-center justify-center rounded-2xl bg-rose-500 px-4 py-3 text-sm font-semibold text-white transition hover:bg-rose-400"
+            >
+              Log out
+            </.link>
+            <p class="text-sm text-zinc-500">
+              If you believe this is a mistake, contact the server operator directly.
+            </p>
+          </div>
+        </div>
+      </div>
+    </Layouts.app>
+    """
+  end
+end

--- a/lib/rfchat_web/live/guild_live.ex
+++ b/lib/rfchat_web/live/guild_live.ex
@@ -13,6 +13,7 @@ defmodule RfchatWeb.GuildLive do
     :ok = Chat.ensure_channel_memberships_for_user(current_user, channels)
     can_manage_channels? = can_manage_channels?(socket.assigns.current_scope)
     can_manage_emojis? = can_manage_emojis?(socket.assigns.current_scope)
+    can_moderate_members? = can_moderate_members?(socket.assigns.current_scope)
 
     if connected?(socket) do
       Chat.subscribe_to_channel_events()
@@ -29,6 +30,7 @@ defmodule RfchatWeb.GuildLive do
       |> assign(:current_user, current_user)
       |> assign(:can_manage_channels?, can_manage_channels?)
       |> assign(:can_manage_emojis?, can_manage_emojis?)
+      |> assign(:can_moderate_members?, can_moderate_members?)
       |> assign(:channels, channels)
       |> assign(:channel_sections, Chat.list_channel_tree_for_user(current_user))
       |> assign(:all_channel_sections, channel_sections_for_manager(can_manage_channels?))
@@ -44,6 +46,9 @@ defmodule RfchatWeb.GuildLive do
       |> assign(:manage_channels_open?, false)
       |> assign(:manage_emojis_open?, false)
       |> assign(:reaction_picker_message_id, nil)
+      |> assign(:member_action_user_id, nil)
+      |> assign(:member_action_form, to_form(Chat.change_moderation_action(%{}), as: :moderation))
+      |> assign(:moderation_cases, [])
       |> assign(:active_channel, nil)
       |> assign(:can_send_messages?, false)
       |> assign(:can_add_reactions?, false)
@@ -194,6 +199,36 @@ defmodule RfchatWeb.GuildLive do
   @impl true
   def handle_event("close_manage_emojis", _params, socket) do
     {:noreply, assign(socket, :manage_emojis_open?, false)}
+  end
+
+  @impl true
+  def handle_event("toggle_member_actions", %{"id" => user_id}, socket) do
+    if socket.assigns.can_moderate_members? do
+      next_user_id = if socket.assigns.member_action_user_id == user_id, do: nil, else: user_id
+
+      moderation_cases =
+        if next_user_id, do: Chat.list_moderation_cases_for_user(user_id), else: []
+
+      {:noreply,
+       socket
+       |> assign(:member_action_user_id, next_user_id)
+       |> assign(:moderation_cases, moderation_cases)
+       |> assign(
+         :member_action_form,
+         to_form(Chat.change_moderation_action(%{}), as: :moderation)
+       )}
+    else
+      {:noreply, put_flash(socket, :error, "You do not have permission to moderate members.")}
+    end
+  end
+
+  @impl true
+  def handle_event("close_member_actions", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:member_action_user_id, nil)
+     |> assign(:moderation_cases, [])
+     |> assign(:member_action_form, to_form(Chat.change_moderation_action(%{}), as: :moderation))}
   end
 
   @impl true
@@ -541,6 +576,43 @@ defmodule RfchatWeb.GuildLive do
     end
   end
 
+  @impl true
+  def handle_event("moderate_member", %{"user_id" => user_id, "moderation" => params}, socket) do
+    if socket.assigns.can_moderate_members? do
+      actor = socket.assigns.current_user
+      subject = Accounts.get_user_with_membership!(user_id)
+
+      case run_member_moderation(actor, subject, params) do
+        {:ok, _subject, _case, message} ->
+          {:noreply,
+           socket
+           |> refresh_member_presence()
+           |> assign(:moderation_cases, Chat.list_moderation_cases_for_user(user_id))
+           |> assign(
+             :member_action_form,
+             to_form(Chat.change_moderation_action(%{}), as: :moderation)
+           )
+           |> put_flash(:info, message)}
+
+        {:error, :forbidden} ->
+          {:noreply,
+           put_flash(socket, :error, "You do not have permission to moderate that member.")}
+
+        {:error, :invalid_duration} ->
+          changeset =
+            Chat.change_moderation_action(params)
+            |> Ecto.Changeset.add_error(:duration_minutes, "must be greater than zero")
+
+          {:noreply, assign(socket, :member_action_form, to_form(changeset, as: :moderation))}
+
+        {:error, _reason} ->
+          {:noreply, put_flash(socket, :error, "Could not complete that moderation action.")}
+      end
+    else
+      {:noreply, put_flash(socket, :error, "You do not have permission to moderate members.")}
+    end
+  end
+
   defp assign_message_form(socket) do
     form =
       %Message{}
@@ -795,6 +867,19 @@ defmodule RfchatWeb.GuildLive do
       permissions = scope_permissions(scope)
 
       Authorization.has_permission?(permissions, :manage_emojis_and_stickers) or
+        Authorization.has_permission?(permissions, :administrator)
+    end
+  end
+
+  defp can_moderate_members?(scope) do
+    if is_nil(scope) do
+      false
+    else
+      permissions = scope_permissions(scope)
+
+      Authorization.has_permission?(permissions, :moderate_members) or
+        Authorization.has_permission?(permissions, :kick_members) or
+        Authorization.has_permission?(permissions, :ban_members) or
         Authorization.has_permission?(permissions, :administrator)
     end
   end
@@ -1164,6 +1249,71 @@ defmodule RfchatWeb.GuildLive do
   defp clear_reply_to_message(socket), do: assign(socket, :reply_to_message, nil)
 
   defp own_message?(message, current_user), do: message.author_id == current_user.id
+
+  defp selected_member(entry, member_action_user_id), do: entry.user.id == member_action_user_id
+
+  defp member_action_available?(current_user, entry, permission_name) do
+    current_user.id != entry.user.id and
+      not entry.user.membership.is_owner and
+      Chat.moderation_permission?(current_user, permission_name)
+  end
+
+  defp moderation_case_label(:timeout), do: "Timeout"
+  defp moderation_case_label(:kick), do: "Kick"
+  defp moderation_case_label(:ban), do: "Ban"
+
+  defp moderation_case_label(other),
+    do: other |> to_string() |> String.replace("_", " ") |> String.capitalize()
+
+  defp member_timeout_label(entry) do
+    timeout_until = entry.user.membership.timeout_until
+
+    if timeout_until && DateTime.compare(timeout_until, DateTime.utc_now()) == :gt do
+      Calendar.strftime(timeout_until, "%b %-d · %H:%M")
+    end
+  end
+
+  defp run_member_moderation(actor, subject, %{
+         "action" => "timeout",
+         "duration_minutes" => minutes,
+         "reason" => reason
+       }) do
+    case Integer.parse(to_string(minutes || "")) do
+      {duration_minutes, ""} when duration_minutes > 0 ->
+        case Chat.timeout_member(actor, subject, duration_minutes, blank_to_nil(reason)) do
+          {:ok, updated_subject, moderation_case} ->
+            {:ok, updated_subject, moderation_case, "Member timed out."}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+
+      _ ->
+        {:error, :invalid_duration}
+    end
+  end
+
+  defp run_member_moderation(actor, subject, %{"action" => "kick", "reason" => reason}) do
+    case Chat.kick_member(actor, subject, blank_to_nil(reason)) do
+      {:ok, updated_subject, moderation_case} ->
+        {:ok, updated_subject, moderation_case, "Member kicked."}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp run_member_moderation(actor, subject, %{"action" => "ban", "reason" => reason}) do
+    case Chat.ban_member(actor, subject, blank_to_nil(reason)) do
+      {:ok, updated_subject, moderation_case} ->
+        {:ok, updated_subject, moderation_case, "Member banned."}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp run_member_moderation(_actor, _subject, _params), do: {:error, :invalid_action}
 
   defp deleted_message?(message) do
     not is_nil(message.deleted_at) or Map.get(message.metadata || %{}, "deleted", false)

--- a/lib/rfchat_web/live/guild_live.ex
+++ b/lib/rfchat_web/live/guild_live.ex
@@ -12,6 +12,7 @@ defmodule RfchatWeb.GuildLive do
     channels = Chat.list_channels_for_user(current_user)
     :ok = Chat.ensure_channel_memberships_for_user(current_user, channels)
     can_manage_channels? = can_manage_channels?(socket.assigns.current_scope)
+    can_manage_emojis? = can_manage_emojis?(socket.assigns.current_scope)
 
     if connected?(socket) do
       Chat.subscribe_to_channel_events()
@@ -19,12 +20,20 @@ defmodule RfchatWeb.GuildLive do
 
     socket =
       socket
+      |> allow_upload(:emoji_image,
+        accept: ~w(.png .jpg .jpeg .gif .webp),
+        max_entries: 1,
+        max_file_size: 512_000
+      )
       |> assign(:guild_name, Application.get_env(:rfchat, :guild_name, "RFChat"))
       |> assign(:current_user, current_user)
       |> assign(:can_manage_channels?, can_manage_channels?)
+      |> assign(:can_manage_emojis?, can_manage_emojis?)
       |> assign(:channels, channels)
       |> assign(:channel_sections, Chat.list_channel_tree_for_user(current_user))
       |> assign(:all_channel_sections, channel_sections_for_manager(can_manage_channels?))
+      |> assign(:custom_emojis, emoji_entries_for_picker(current_user))
+      |> assign(:custom_emojis_json, emoji_entries_json_for_picker(current_user))
       |> assign(:member_presence, Accounts.list_members_with_presence())
       |> assign(:notification_setting, Chat.get_user_notification_setting(current_user))
       |> assign(:composer_mentions_json, Jason.encode!(Chat.composer_mentions()))
@@ -33,6 +42,8 @@ defmodule RfchatWeb.GuildLive do
       |> assign(:unread_mentions, Chat.unread_mentions_for_user(current_user, channels))
       |> assign(:mobile_sidebar_open?, false)
       |> assign(:manage_channels_open?, false)
+      |> assign(:manage_emojis_open?, false)
+      |> assign(:reaction_picker_message_id, nil)
       |> assign(:active_channel, nil)
       |> assign(:can_send_messages?, false)
       |> assign(:can_add_reactions?, false)
@@ -44,6 +55,7 @@ defmodule RfchatWeb.GuildLive do
       |> assign(:channel_form_mode, :create_text)
       |> assign(:channel_form_title, "Create text channel")
       |> assign(:editing_channel_id, nil)
+      |> assign(:emoji_form, to_form(Chat.change_emoji(%Chat.Emoji{}, %{}), as: :emoji))
       |> assign(:message_count, 0)
       |> assign(:messages_empty?, true)
       |> assign_message_form()
@@ -168,6 +180,20 @@ defmodule RfchatWeb.GuildLive do
   @impl true
   def handle_event("close_manage_channels", _params, socket) do
     {:noreply, assign(socket, :manage_channels_open?, false)}
+  end
+
+  @impl true
+  def handle_event("toggle_manage_emojis", _params, socket) do
+    if socket.assigns.can_manage_emojis? do
+      {:noreply, assign(socket, :manage_emojis_open?, !socket.assigns.manage_emojis_open?)}
+    else
+      {:noreply, put_flash(socket, :error, "You do not have permission to manage emojis.")}
+    end
+  end
+
+  @impl true
+  def handle_event("close_manage_emojis", _params, socket) do
+    {:noreply, assign(socket, :manage_emojis_open?, false)}
   end
 
   @impl true
@@ -420,7 +446,11 @@ defmodule RfchatWeb.GuildLive do
 
     case Chat.toggle_reaction(message, socket.assigns.current_user, emoji_unicode) do
       {:ok, updated_message} ->
-        {:noreply, stream_insert(socket, :messages, updated_message)}
+        {:noreply,
+         socket
+         |> assign(:reaction_picker_message_id, nil)
+         |> rerender_messages([message.id])
+         |> stream_insert(:messages, updated_message)}
 
       {:error, :invalid_emoji} ->
         {:noreply, put_flash(socket, :error, "Choose a valid reaction.")}
@@ -430,6 +460,84 @@ defmodule RfchatWeb.GuildLive do
 
       {:error, _changeset} ->
         {:noreply, put_flash(socket, :error, "Could not toggle that reaction.")}
+    end
+  end
+
+  @impl true
+  def handle_event(
+        "toggle_custom_reaction",
+        %{"id" => message_id, "emoji_id" => emoji_id},
+        socket
+      ) do
+    message = Chat.get_message!(message_id)
+
+    case Chat.toggle_reaction(message, socket.assigns.current_user, %{"emoji_id" => emoji_id}) do
+      {:ok, updated_message} ->
+        {:noreply,
+         socket
+         |> assign(:reaction_picker_message_id, nil)
+         |> rerender_messages([message.id])
+         |> stream_insert(:messages, updated_message)}
+
+      {:error, :invalid_emoji} ->
+        {:noreply, put_flash(socket, :error, "Choose a valid custom emoji.")}
+
+      {:error, :forbidden} ->
+        {:noreply,
+         put_flash(socket, :error, "You do not have permission to use that emoji here.")}
+
+      {:error, _changeset} ->
+        {:noreply, put_flash(socket, :error, "Could not toggle that reaction.")}
+    end
+  end
+
+  @impl true
+  def handle_event("toggle_reaction_picker", %{"id" => message_id}, socket) do
+    previous_message_id = socket.assigns.reaction_picker_message_id
+
+    next_message_id =
+      if previous_message_id == message_id, do: nil, else: message_id
+
+    {:noreply,
+     socket
+     |> assign(:reaction_picker_message_id, next_message_id)
+     |> rerender_messages([previous_message_id, next_message_id])}
+  end
+
+  @impl true
+  def handle_event("close_reaction_picker", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:reaction_picker_message_id, nil)
+     |> rerender_messages([socket.assigns.reaction_picker_message_id])}
+  end
+
+  @impl true
+  def handle_event("save_emoji", %{"emoji" => emoji_params}, socket) do
+    if socket.assigns.can_manage_emojis? do
+      save_emoji(socket, emoji_params)
+    else
+      {:noreply, put_flash(socket, :error, "You do not have permission to manage emojis.")}
+    end
+  end
+
+  @impl true
+  def handle_event("delete_emoji", %{"id" => emoji_id}, socket) do
+    if socket.assigns.can_manage_emojis? do
+      emoji = Chat.get_emoji!(emoji_id)
+
+      case Chat.delete_custom_emoji(emoji) do
+        {:ok, _emoji} ->
+          {:noreply,
+           socket
+           |> refresh_custom_emojis()
+           |> put_flash(:info, "Emoji deleted.")}
+
+        {:error, _reason} ->
+          {:noreply, put_flash(socket, :error, "Could not delete that emoji.")}
+      end
+    else
+      {:noreply, put_flash(socket, :error, "You do not have permission to manage emojis.")}
     end
   end
 
@@ -485,6 +593,7 @@ defmodule RfchatWeb.GuildLive do
       channel_sections_for_manager(socket.assigns.can_manage_channels?)
     )
     |> assign(:mobile_sidebar_open?, false)
+    |> assign(:reaction_picker_message_id, nil)
     |> assign(:active_channel, refreshed_active_channel)
     |> assign(
       :can_send_messages?,
@@ -540,6 +649,7 @@ defmodule RfchatWeb.GuildLive do
       channel_sections_for_manager(socket.assigns.can_manage_channels?)
     )
     |> assign(:active_channel, active_channel)
+    |> assign(:reaction_picker_message_id, nil)
     |> assign(
       :can_send_messages?,
       if(active_channel, do: Chat.can_send_messages?(active_channel, current_user), else: false)
@@ -604,6 +714,20 @@ defmodule RfchatWeb.GuildLive do
     assign(socket, :member_presence, Accounts.list_members_with_presence())
   end
 
+  defp rerender_messages(socket, message_ids) do
+    Enum.reduce(Enum.reject(message_ids, &is_nil/1), socket, fn message_id, acc ->
+      stream_insert(acc, :messages, Chat.get_message!(message_id))
+    end)
+  end
+
+  defp refresh_custom_emojis(socket) do
+    current_user = socket.assigns.current_user
+
+    socket
+    |> assign(:custom_emojis, emoji_entries_for_picker(current_user))
+    |> assign(:custom_emojis_json, emoji_entries_json_for_picker(current_user))
+  end
+
   defp maybe_push_mention_notification(socket, message) do
     current_user = socket.assigns.current_user
     active_channel = socket.assigns.active_channel
@@ -653,13 +777,26 @@ defmodule RfchatWeb.GuildLive do
     setting.desktop_enabled && setting.notify_on_mentions
   end
 
-  defp can_manage_channels?(nil), do: false
-
   defp can_manage_channels?(scope) do
-    permissions = scope_permissions(scope)
+    if is_nil(scope) do
+      false
+    else
+      permissions = scope_permissions(scope)
 
-    Authorization.has_permission?(permissions, :manage_channels) or
-      Authorization.has_permission?(permissions, :administrator)
+      Authorization.has_permission?(permissions, :manage_channels) or
+        Authorization.has_permission?(permissions, :administrator)
+    end
+  end
+
+  defp can_manage_emojis?(scope) do
+    if is_nil(scope) do
+      false
+    else
+      permissions = scope_permissions(scope)
+
+      Authorization.has_permission?(permissions, :manage_emojis_and_stickers) or
+        Authorization.has_permission?(permissions, :administrator)
+    end
   end
 
   defp scope_permissions(%{
@@ -905,15 +1042,116 @@ defmodule RfchatWeb.GuildLive do
   defp mobile_sidebar_overlay_class(true), do: "opacity-100 pointer-events-auto"
   defp mobile_sidebar_overlay_class(false), do: "pointer-events-none opacity-0"
 
-  defp reaction_count(message, emoji_unicode) do
+  defp emoji_upload_error(:too_large), do: "That file is too large."
+  defp emoji_upload_error(:too_many_files), do: "Choose only one file."
+  defp emoji_upload_error(:not_accepted), do: "That file type is not allowed."
+  defp emoji_upload_error(_error), do: "Upload failed."
+
+  defp reaction_summaries(message, current_user) do
     message.reactions
-    |> Enum.count(&(&1.emoji_unicode == emoji_unicode))
+    |> Enum.group_by(fn reaction ->
+      if reaction.emoji_id,
+        do: {:custom, reaction.emoji_id},
+        else: {:unicode, reaction.emoji_unicode}
+    end)
+    |> Enum.map(fn
+      {{:custom, emoji_id}, reactions} ->
+        reaction = List.first(reactions)
+
+        %{
+          kind: :custom,
+          emoji_id: emoji_id,
+          emoji_unicode: nil,
+          label: reaction.emoji && reaction.emoji.name,
+          url: reaction.emoji && reaction.emoji.asset && Chat.asset_url(reaction.emoji.asset),
+          count: length(reactions),
+          reacted?: Enum.any?(reactions, &(&1.user_id == current_user.id))
+        }
+
+      {{:unicode, emoji_unicode}, reactions} ->
+        %{
+          kind: :unicode,
+          emoji_id: nil,
+          emoji_unicode: emoji_unicode,
+          label: emoji_unicode,
+          url: nil,
+          count: length(reactions),
+          reacted?: Enum.any?(reactions, &(&1.user_id == current_user.id))
+        }
+    end)
+    |> Enum.sort_by(fn summary ->
+      case summary.kind do
+        :unicode -> {0, summary.label}
+        :custom -> {1, summary.label || ""}
+      end
+    end)
   end
 
-  defp reacted_by_current_user?(message, current_user, emoji_unicode) do
-    Enum.any?(message.reactions, fn reaction ->
-      reaction.user_id == current_user.id and reaction.emoji_unicode == emoji_unicode
+  defp reaction_picker_open?(message, reaction_picker_message_id) do
+    reaction_picker_message_id == message.id
+  end
+
+  defp emoji_entries_for_picker(current_user) do
+    Chat.list_available_emojis(current_user)
+    |> Enum.map(fn emoji ->
+      %{
+        id: emoji.id,
+        name: emoji.name,
+        shortcode: emoji.shortcode,
+        url: Chat.asset_url(emoji.asset)
+      }
     end)
+  end
+
+  defp emoji_entries_json_for_picker(current_user) do
+    current_user
+    |> emoji_entries_for_picker()
+    |> Jason.encode!()
+  end
+
+  defp save_emoji(socket, emoji_params) do
+    upload = uploaded_entry(socket, :emoji_image)
+
+    if is_nil(upload) do
+      {:noreply, put_flash(socket, :error, "Choose an image before saving the emoji.")}
+    else
+      case consume_emoji_upload(socket, upload, emoji_params) do
+        {:ok, _emoji, socket} ->
+          {:noreply,
+           socket
+           |> refresh_custom_emojis()
+           |> assign(:emoji_form, to_form(Chat.change_emoji(%Chat.Emoji{}, %{}), as: :emoji))
+           |> put_flash(:info, "Emoji added.")}
+
+        {:error, :invalid_upload_type, socket} ->
+          {:noreply, put_flash(socket, :error, "Emoji uploads must be png, jpg, gif, or webp.")}
+
+        {:error, changeset, socket} ->
+          {:noreply, assign(socket, :emoji_form, to_form(changeset, as: :emoji))}
+      end
+    end
+  end
+
+  defp consume_emoji_upload(socket, _upload, emoji_params) do
+    result =
+      consume_uploaded_entries(socket, :emoji_image, fn %{path: path}, entry ->
+        {:ok,
+         Chat.create_custom_emoji_from_upload(emoji_params, socket.assigns.current_user, %{
+           path: path,
+           client_name: entry.client_name,
+           client_type: entry.client_type
+         })}
+      end)
+
+    case result do
+      [{:ok, emoji}] -> {:ok, emoji, socket}
+      [{:error, reason}] -> {:error, reason, socket}
+      [] -> {:error, :invalid_upload_type, socket}
+    end
+  end
+
+  defp uploaded_entry(socket, name) do
+    socket.assigns.uploads[name].entries |> List.first()
   end
 
   defp maybe_put_reply(socket, message_params) do

--- a/lib/rfchat_web/live/guild_live.html.heex
+++ b/lib/rfchat_web/live/guild_live.html.heex
@@ -52,6 +52,16 @@
             </span>
 
             <button
+              :if={@can_manage_emojis?}
+              type="button"
+              phx-click="toggle_manage_emojis"
+              id="open-emoji-manager"
+              class="rounded-md px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-zinc-400 transition hover:bg-white/8 hover:text-white"
+            >
+              Emoji
+            </button>
+
+            <button
               :if={@can_manage_channels?}
               type="button"
               phx-click="toggle_manage_channels"
@@ -412,6 +422,146 @@
       </div>
     </aside>
 
+    <div
+      :if={@can_manage_emojis?}
+      id="emoji-manager-overlay"
+      class={[
+        "fixed inset-0 z-40 bg-black/70 transition",
+        @manage_emojis_open? && "opacity-100 pointer-events-auto",
+        !@manage_emojis_open? && "pointer-events-none opacity-0"
+      ]}
+      phx-click="close_manage_emojis"
+    />
+
+    <aside
+      :if={@can_manage_emojis?}
+      id="emoji-manager-panel"
+      class={[
+        "fixed inset-y-0 right-0 z-50 flex w-full max-w-lg flex-col border-l border-black/30 bg-[#202225] shadow-[-16px_0_48px_rgba(0,0,0,0.45)] transition-transform duration-200 ease-out",
+        @manage_emojis_open? && "translate-x-0",
+        !@manage_emojis_open? && "translate-x-full"
+      ]}
+    >
+      <div class="flex items-center justify-between border-b border-black/20 px-5 py-4">
+        <div>
+          <p class="text-[11px] font-bold uppercase tracking-[0.2em] text-zinc-500">
+            Server assets
+          </p>
+          <h2 class="mt-1 text-lg font-semibold text-white">Custom emoji</h2>
+        </div>
+
+        <button
+          type="button"
+          phx-click="close_manage_emojis"
+          id="close-emoji-manager"
+          class="rounded-md px-2 py-1 text-[11px] font-semibold text-zinc-400 transition hover:bg-white/8 hover:text-white"
+        >
+          Close
+        </button>
+      </div>
+
+      <div class="grid min-h-0 flex-1 gap-0 lg:grid-cols-[1.05fr_0.95fr]">
+        <div class="min-h-0 overflow-y-auto border-b border-black/20 px-4 py-4 lg:border-b-0 lg:border-r chat-scrollbar">
+          <div class="flex items-center justify-between gap-3">
+            <div>
+              <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-zinc-500">
+                Library
+              </p>
+              <p class="mt-1 text-xs text-zinc-400">Upload small reaction-ready emoji assets.</p>
+            </div>
+            <span class="rounded bg-black/20 px-2 py-1 text-[10px] font-semibold text-zinc-400">
+              {length(@custom_emojis)} total
+            </span>
+          </div>
+
+          <div class="mt-4 grid gap-3 sm:grid-cols-2">
+            <div
+              :for={emoji <- @custom_emojis}
+              id={"manage-emoji-#{emoji.id}"}
+              class="rounded-xl border border-white/8 bg-black/10 p-3"
+            >
+              <div class="flex items-start justify-between gap-3">
+                <div class="flex min-w-0 items-center gap-3">
+                  <img
+                    src={emoji.url}
+                    alt={emoji.name}
+                    class="size-10 rounded-lg bg-black/20 object-cover"
+                  />
+                  <div class="min-w-0">
+                    <p class="truncate text-sm font-semibold text-zinc-100">{emoji.name}</p>
+                    <p class="truncate text-[11px] text-zinc-400">{emoji.shortcode}</p>
+                  </div>
+                </div>
+
+                <button
+                  type="button"
+                  phx-click="delete_emoji"
+                  phx-value-id={emoji.id}
+                  id={"delete-emoji-#{emoji.id}"}
+                  class="rounded px-2 py-1 text-[11px] font-semibold text-rose-300 transition hover:bg-rose-500/10 hover:text-rose-100"
+                >
+                  Delete
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="min-h-0 overflow-y-auto px-4 py-4 chat-scrollbar">
+          <div class="rounded-xl border border-white/8 bg-black/10 p-4">
+            <div>
+              <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-zinc-500">
+                Upload
+              </p>
+              <h3 class="mt-1 text-base font-semibold text-white">Add custom emoji</h3>
+            </div>
+
+            <.form
+              for={@emoji_form}
+              id="emoji-form"
+              phx-submit="save_emoji"
+              class="mt-4 space-y-4"
+            >
+              <.input field={@emoji_form[:name]} type="text" label="Name" />
+              <.input field={@emoji_form[:shortcode]} type="text" label="Shortcode" />
+
+              <div>
+                <label class="mb-2 block text-sm font-medium text-zinc-200">Image</label>
+                <div class="rounded-xl border border-dashed border-white/10 bg-black/10 p-4">
+                  <.live_file_input
+                    upload={@uploads.emoji_image}
+                    class="block w-full text-sm text-zinc-200"
+                  />
+                  <p class="mt-2 text-[11px] text-zinc-500">
+                    png, jpg, gif, or webp. keep it tiny.
+                  </p>
+                </div>
+                <p
+                  :for={err <- upload_errors(@uploads.emoji_image)}
+                  class="mt-2 text-[11px] text-rose-300"
+                >
+                  {emoji_upload_error(err)}
+                </p>
+              </div>
+
+              <div class="flex items-center justify-end gap-2 pt-2">
+                <button
+                  type="button"
+                  phx-click="close_manage_emojis"
+                  class="rounded-md px-3 py-1.5 text-[11px] font-semibold text-zinc-400 transition hover:bg-white/8 hover:text-white"
+                >
+                  Close
+                </button>
+                <.button class="rounded-md bg-violet-500 px-3 py-1.5 text-[11px] font-semibold text-white transition hover:bg-violet-400">
+                  Save emoji
+                </.button>
+              </div>
+            </.form>
+          </div>
+        </div>
+      </div>
+    </aside>
+
     <section class="flex min-h-0 min-w-0 flex-1 flex-col bg-[#313338]">
       <%= if @active_channel do %>
         <header class="flex items-center justify-between border-b border-black/20 bg-[#313338]/95 px-4 py-3 shadow-[0_1px_0_rgba(0,0,0,0.2)] backdrop-blur">
@@ -554,26 +704,173 @@
 
                   <div class="mt-2 flex flex-wrap items-center gap-1.5">
                     <button
-                      :for={emoji <- ["👍", "🔥", "❤️"]}
+                      :for={reaction <- reaction_summaries(message, @current_user)}
                       type="button"
-                      phx-click="toggle_reaction"
+                      phx-click={
+                        if reaction.kind == :unicode,
+                          do: "toggle_reaction",
+                          else: "toggle_custom_reaction"
+                      }
                       phx-value-id={message.id}
-                      phx-value-emoji={emoji}
-                      id={"reaction-#{message.id}-#{Base.url_encode64(emoji, padding: false)}"}
+                      phx-value-emoji={reaction.emoji_unicode}
+                      phx-value-emoji_id={reaction.emoji_id}
+                      id={
+                        if reaction.kind == :unicode,
+                          do:
+                            "reaction-#{message.id}-#{Base.url_encode64(reaction.emoji_unicode, padding: false)}",
+                          else: "reaction-#{message.id}-custom-#{reaction.emoji_id}"
+                      }
                       disabled={!@can_add_reactions? or deleted_message?(message)}
                       class={[
                         "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-semibold transition",
-                        reacted_by_current_user?(message, @current_user, emoji) &&
+                        reaction.reacted? &&
                           "border-violet-400/60 bg-violet-500/20 text-violet-100",
-                        not reacted_by_current_user?(message, @current_user, emoji) &&
+                        !reaction.reacted? &&
                           "border-white/8 bg-black/10 text-zinc-400 hover:border-white/15 hover:text-zinc-200",
                         (!@can_add_reactions? or deleted_message?(message)) &&
                           "cursor-not-allowed opacity-50 hover:border-white/8 hover:text-zinc-400"
                       ]}
                     >
-                      <span>{emoji}</span>
-                      <span>{reaction_count(message, emoji)}</span>
+                      <span :if={reaction.kind == :unicode}>{reaction.emoji_unicode}</span>
+                      <img
+                        :if={reaction.kind == :custom}
+                        src={reaction.url}
+                        alt={reaction.label}
+                        class="size-4 rounded object-cover"
+                      />
+                      <span>{reaction.count}</span>
                     </button>
+
+                    <div class="relative">
+                      <button
+                        type="button"
+                        phx-click="toggle_reaction_picker"
+                        phx-value-id={message.id}
+                        id={"open-reaction-picker-#{message.id}"}
+                        disabled={!@can_add_reactions? or deleted_message?(message)}
+                        class={[
+                          "inline-flex items-center gap-1 rounded-full border border-dashed px-2 py-0.5 text-[11px] font-semibold transition",
+                          reaction_picker_open?(message, @reaction_picker_message_id) &&
+                            "border-violet-400/60 bg-violet-500/20 text-violet-100",
+                          !reaction_picker_open?(message, @reaction_picker_message_id) &&
+                            "border-white/10 bg-black/10 text-zinc-400 hover:border-white/20 hover:text-zinc-200",
+                          (!@can_add_reactions? or deleted_message?(message)) &&
+                            "cursor-not-allowed opacity-50 hover:border-white/10 hover:text-zinc-400"
+                        ]}
+                      >
+                        <span>+</span>
+                        <span>Add reaction</span>
+                      </button>
+
+                      <div
+                        :if={reaction_picker_open?(message, @reaction_picker_message_id)}
+                        id={"reaction-picker-#{message.id}"}
+                        phx-hook="ReactionPickerHook"
+                        data-custom-emojis={@custom_emojis_json}
+                        class="absolute left-0 top-full z-20 mt-2 w-72 rounded-2xl border border-white/10 bg-[#1c1d21] p-3 shadow-[0_18px_48px_rgba(0,0,0,0.45)]"
+                      >
+                        <div class="mb-2 flex items-center justify-between gap-3">
+                          <div>
+                            <p class="text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">
+                              Reactions
+                            </p>
+                            <p class="mt-1 text-xs text-zinc-400">
+                              Pick a default or custom emoji.
+                            </p>
+                          </div>
+                          <button
+                            type="button"
+                            phx-click="close_reaction_picker"
+                            id={"close-reaction-picker-#{message.id}"}
+                            class="rounded-md px-2 py-1 text-[10px] font-semibold text-zinc-400 transition hover:bg-white/8 hover:text-white"
+                          >
+                            Close
+                          </button>
+                        </div>
+
+                        <div class="space-y-3">
+                          <div>
+                            <label
+                              for={"reaction-picker-search-#{message.id}"}
+                              class="mb-2 block text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-500"
+                            >
+                              Search
+                            </label>
+                            <input
+                              id={"reaction-picker-search-#{message.id}"}
+                              type="search"
+                              placeholder="Search emojis"
+                              data-reaction-picker-search
+                              class="w-full rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-sm text-zinc-100 outline-none transition placeholder:text-zinc-500 focus:border-violet-400/60"
+                            />
+                          </div>
+
+                          <div>
+                            <p class="mb-2 text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-500">
+                              Default
+                            </p>
+                            <div
+                              data-reaction-picker-categories
+                              class="mb-2 flex flex-wrap gap-1.5"
+                            />
+                            <div
+                              data-reaction-picker-defaults
+                              data-message-id={message.id}
+                              class="grid max-h-72 grid-cols-6 gap-2 overflow-y-auto pr-1 chat-scrollbar"
+                            >
+                              <button
+                                :for={emoji <- Chat.default_reaction_emojis()}
+                                type="button"
+                                phx-click="toggle_reaction"
+                                phx-value-id={message.id}
+                                phx-value-emoji={emoji}
+                                id={"reaction-picker-default-#{message.id}-#{Base.url_encode64(emoji, padding: false)}"}
+                                class="flex h-10 items-center justify-center rounded-xl border border-white/8 bg-black/10 text-lg transition hover:border-white/20 hover:bg-white/6"
+                              >
+                                <span>{emoji}</span>
+                              </button>
+                            </div>
+                          </div>
+
+                          <div>
+                            <p class="mb-2 text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-500">
+                              Custom
+                            </p>
+                            <div
+                              :if={@custom_emojis != []}
+                              class="grid grid-cols-4 gap-2"
+                              data-reaction-picker-custom
+                            >
+                              <button
+                                :for={emoji <- @custom_emojis}
+                                type="button"
+                                phx-click="toggle_custom_reaction"
+                                phx-value-id={message.id}
+                                phx-value-emoji_id={emoji.id}
+                                id={"reaction-picker-custom-#{message.id}-#{emoji.id}"}
+                                data-custom-emoji-id={emoji.id}
+                                data-custom-emoji-name={emoji.name}
+                                data-custom-emoji-shortcode={emoji.shortcode}
+                                class="flex flex-col items-center gap-1 rounded-xl border border-white/8 bg-black/10 px-2 py-2 text-[10px] font-medium text-zinc-300 transition hover:border-white/20 hover:bg-white/6 hover:text-white"
+                              >
+                                <img
+                                  src={emoji.url}
+                                  alt={emoji.name}
+                                  class="size-6 rounded-md object-cover"
+                                />
+                                <span class="max-w-full truncate">{emoji.name}</span>
+                              </button>
+                            </div>
+                            <p
+                              :if={@custom_emojis == []}
+                              class="rounded-xl border border-dashed border-white/8 bg-black/10 px-3 py-3 text-xs text-zinc-500"
+                            >
+                              No custom emoji uploaded yet.
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                   </div>
 
                   <p :if={!@can_add_reactions?} class="mt-2 text-[11px] text-zinc-500">

--- a/lib/rfchat_web/live/guild_live.html.heex
+++ b/lib/rfchat_web/live/guild_live.html.heex
@@ -1105,6 +1105,154 @@
                   "%b %-d · %H:%M"
                 )}
               </p>
+
+              <div class="mt-2 flex flex-wrap items-center gap-1.5">
+                <span
+                  :if={member_timeout_label(entry)}
+                  class="rounded bg-amber-500/15 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.16em] text-amber-200"
+                >
+                  timed out until {member_timeout_label(entry)}
+                </span>
+
+                <span
+                  :if={
+                    entry.user.membership.deactivated_at &&
+                      Map.get(entry.user.membership.flags || %{}, "banned")
+                  }
+                  class="rounded bg-rose-500/15 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.16em] text-rose-200"
+                >
+                  banned
+                </span>
+              </div>
+
+              <button
+                :if={
+                  @can_moderate_members? && !entry.user.membership.is_owner &&
+                    entry.user.id != @current_user.id
+                }
+                type="button"
+                phx-click="toggle_member_actions"
+                phx-value-id={entry.user.id}
+                id={"open-member-actions-#{entry.user.id}"}
+                class="mt-3 rounded-md border border-white/8 px-2.5 py-1 text-[11px] font-semibold text-zinc-300 transition hover:border-white/15 hover:bg-white/5 hover:text-white"
+              >
+                Moderate
+              </button>
+            </div>
+          </div>
+
+          <div
+            :if={selected_member(entry, @member_action_user_id)}
+            id={"member-actions-#{entry.user.id}"}
+            class="mt-3 rounded-xl border border-white/8 bg-black/15 p-3"
+          >
+            <div class="mb-3 flex items-center justify-between gap-3">
+              <div>
+                <p class="text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">
+                  Moderation
+                </p>
+                <p class="mt-1 text-xs text-zinc-400">Take action on @{entry.user.username}</p>
+              </div>
+
+              <button
+                type="button"
+                phx-click="close_member_actions"
+                id={"close-member-actions-#{entry.user.id}"}
+                class="rounded-md px-2 py-1 text-[10px] font-semibold text-zinc-400 transition hover:bg-white/8 hover:text-white"
+              >
+                Close
+              </button>
+            </div>
+
+            <.form
+              for={@member_action_form}
+              id={"member-action-form-#{entry.user.id}"}
+              phx-submit="moderate_member"
+              class="space-y-3"
+            >
+              <input type="hidden" name="user_id" value={entry.user.id} />
+
+              <.input
+                field={@member_action_form[:action]}
+                type="select"
+                label="Action"
+                options={[
+                  {"Timeout", "timeout"},
+                  {"Kick", "kick"},
+                  {"Ban", "ban"}
+                ]}
+              />
+
+              <.input
+                field={@member_action_form[:duration_minutes]}
+                type="number"
+                label="Timeout minutes"
+                min="1"
+              />
+
+              <.input field={@member_action_form[:reason]} type="text" label="Reason" />
+
+              <div class="flex flex-wrap items-center gap-2">
+                <button
+                  :if={member_action_available?(@current_user, entry, :moderate_members)}
+                  type="submit"
+                  class="rounded-md bg-amber-500 px-3 py-1.5 text-[11px] font-semibold text-black transition hover:bg-amber-400"
+                  name="moderation[action]"
+                  value="timeout"
+                >
+                  Timeout
+                </button>
+
+                <button
+                  :if={member_action_available?(@current_user, entry, :kick_members)}
+                  type="submit"
+                  class="rounded-md bg-orange-500 px-3 py-1.5 text-[11px] font-semibold text-white transition hover:bg-orange-400"
+                  name="moderation[action]"
+                  value="kick"
+                >
+                  Kick
+                </button>
+
+                <button
+                  :if={member_action_available?(@current_user, entry, :ban_members)}
+                  type="submit"
+                  class="rounded-md bg-rose-500 px-3 py-1.5 text-[11px] font-semibold text-white transition hover:bg-rose-400"
+                  name="moderation[action]"
+                  value="ban"
+                >
+                  Ban
+                </button>
+              </div>
+            </.form>
+
+            <div class="mt-4 border-t border-white/8 pt-3">
+              <p class="text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">
+                Recent cases
+              </p>
+
+              <div :if={@moderation_cases != []} class="mt-2 space-y-2">
+                <div
+                  :for={moderation_case <- Enum.take(@moderation_cases, 5)}
+                  class="rounded-lg border border-white/8 bg-black/10 px-3 py-2"
+                >
+                  <div class="flex items-center justify-between gap-2">
+                    <p class="text-[11px] font-semibold text-zinc-100">
+                      {moderation_case_label(moderation_case.action_type)}
+                    </p>
+                    <p class="text-[10px] text-zinc-500">Case #{moderation_case.case_number}</p>
+                  </div>
+                  <p class="mt-1 text-[11px] text-zinc-400">
+                    by {moderation_case.actor_user && moderation_case.actor_user.display_name}
+                  </p>
+                  <p :if={moderation_case.reason} class="mt-1 text-[11px] text-zinc-300">
+                    {moderation_case.reason}
+                  </p>
+                </div>
+              </div>
+
+              <p :if={@moderation_cases == []} class="mt-2 text-xs text-zinc-500">
+                No moderation cases yet.
+              </p>
             </div>
           </div>
         </div>

--- a/lib/rfchat_web/router.ex
+++ b/lib/rfchat_web/router.ex
@@ -15,6 +15,10 @@ defmodule RfchatWeb.Router do
     plug(RfchatWeb.UserAuth, :require_authenticated_user)
   end
 
+  pipeline :require_banned_user do
+    plug(RfchatWeb.UserAuth, :require_banned_user)
+  end
+
   pipeline :redirect_if_user_is_authenticated do
     plug(RfchatWeb.UserAuth, :redirect_if_user_is_authenticated)
   end
@@ -47,6 +51,15 @@ defmodule RfchatWeb.Router do
     live_session :require_authenticated_user,
       on_mount: [{RfchatWeb.UserAuth, :ensure_authenticated}] do
       live("/", GuildLive, :index)
+    end
+  end
+
+  scope "/", RfchatWeb do
+    pipe_through([:browser, :require_banned_user])
+
+    live_session :require_banned_user,
+      on_mount: [{RfchatWeb.UserAuth, :ensure_banned_user}] do
+      live("/banned", BannedLive, :index)
     end
   end
 

--- a/lib/rfchat_web/user_auth.ex
+++ b/lib/rfchat_web/user_auth.ex
@@ -17,14 +17,27 @@ defmodule RfchatWeb.UserAuth do
   end
 
   def log_in_user(conn, user, params \\ %{}) do
-    token = Accounts.generate_user_session_token(user, session_metadata(conn))
-    user_return_to = get_session(conn, :user_return_to)
+    user = Accounts.get_user_with_membership!(user.id)
 
-    conn
-    |> renew_session()
-    |> put_session(:user_token, token)
-    |> maybe_write_remember_me_cookie(token, params)
-    |> redirect(to: user_return_to || signed_in_path(conn))
+    if Accounts.banned?(user) do
+      token = Accounts.generate_user_session_token(user, session_metadata(conn))
+
+      conn
+      |> renew_session()
+      |> put_session(:user_token, token)
+      |> maybe_write_remember_me_cookie(token, params)
+      |> put_flash(:error, banned_message(user))
+      |> redirect(to: ~p"/banned")
+    else
+      token = Accounts.generate_user_session_token(user, session_metadata(conn))
+      user_return_to = get_session(conn, :user_return_to)
+
+      conn
+      |> renew_session()
+      |> put_session(:user_token, token)
+      |> maybe_write_remember_me_cookie(token, params)
+      |> redirect(to: user_return_to || signed_in_path(conn))
+    end
   end
 
   def log_out_user(conn) do
@@ -51,13 +64,30 @@ defmodule RfchatWeb.UserAuth do
   end
 
   def require_authenticated_user(conn, _opts) do
-    if conn.assigns.current_user do
+    cond do
+      conn.assigns.current_user && Accounts.banned?(conn.assigns.current_user) ->
+        conn
+        |> redirect(to: ~p"/banned")
+        |> halt()
+
+      conn.assigns.current_user ->
+        conn
+
+      true ->
+        conn
+        |> put_flash(:error, "Please log in to continue.")
+        |> maybe_store_return_to()
+        |> redirect(to: ~p"/login")
+        |> halt()
+    end
+  end
+
+  def require_banned_user(conn, _opts) do
+    if conn.assigns.current_user && Accounts.banned?(conn.assigns.current_user) do
       conn
     else
       conn
-      |> put_flash(:error, "Please log in to continue.")
-      |> maybe_store_return_to()
-      |> redirect(to: ~p"/login")
+      |> redirect(to: if(conn.assigns.current_user, do: ~p"/", else: ~p"/login"))
       |> halt()
     end
   end
@@ -65,7 +95,13 @@ defmodule RfchatWeb.UserAuth do
   def redirect_if_user_is_authenticated(conn, _opts) do
     if conn.assigns.current_user do
       conn
-      |> redirect(to: signed_in_path(conn))
+      |> redirect(
+        to:
+          if(Accounts.banned?(conn.assigns.current_user),
+            do: ~p"/banned",
+            else: signed_in_path(conn)
+          )
+      )
       |> halt()
     else
       conn
@@ -79,13 +115,29 @@ defmodule RfchatWeb.UserAuth do
   def on_mount(:ensure_authenticated, _params, session, socket) do
     socket = mount_current_scope(socket, session)
 
-    if socket.assigns.current_user do
+    cond do
+      socket.assigns.current_user && Accounts.banned?(socket.assigns.current_user) ->
+        {:halt, LiveView.redirect(socket, to: ~p"/banned")}
+
+      socket.assigns.current_user ->
+        {:cont, socket}
+
+      true ->
+        {:halt,
+         socket
+         |> LiveView.put_flash(:error, "Please log in to continue.")
+         |> LiveView.redirect(to: ~p"/login")}
+    end
+  end
+
+  def on_mount(:ensure_banned_user, _params, session, socket) do
+    socket = mount_current_scope(socket, session)
+
+    if socket.assigns.current_user && Accounts.banned?(socket.assigns.current_user) do
       {:cont, socket}
     else
       {:halt,
-       socket
-       |> LiveView.put_flash(:error, "Please log in to continue.")
-       |> LiveView.redirect(to: ~p"/login")}
+       LiveView.redirect(socket, to: if(socket.assigns.current_user, do: ~p"/", else: ~p"/login"))}
     end
   end
 
@@ -93,7 +145,11 @@ defmodule RfchatWeb.UserAuth do
     socket = mount_current_scope(socket, session)
 
     if socket.assigns.current_user do
-      {:halt, LiveView.redirect(socket, to: ~p"/")}
+      {:halt,
+       LiveView.redirect(
+         socket,
+         to: if(Accounts.banned?(socket.assigns.current_user), do: ~p"/banned", else: ~p"/")
+       )}
     else
       {:cont, socket}
     end
@@ -114,6 +170,16 @@ defmodule RfchatWeb.UserAuth do
 
   defp maybe_store_return_to(conn), do: conn
   defp signed_in_path(_conn), do: ~p"/"
+
+  defp banned_message(user) do
+    reason = user.membership.flags |> Kernel.||(%{}) |> Map.get("ban_reason")
+
+    if is_binary(reason) and String.trim(reason) != "" do
+      "This account is banned from this server. Reason: #{String.trim(reason)}"
+    else
+      "This account is banned from this server."
+    end
+  end
 
   defp maybe_write_remember_me_cookie(conn, token, %{"remember_me" => "true"}) do
     put_resp_cookie(conn, @remember_me_cookie, token, @remember_me_options)

--- a/test/rfchat/chat_test.exs
+++ b/test/rfchat/chat_test.exs
@@ -341,6 +341,53 @@ defmodule Rfchat.ChatTest do
       assert Enum.any?(Chat.list_available_emojis(user), &(&1.id == emoji.id))
     end
 
+    test "timeout_member/4 blocks sending and reactions until timeout expires" do
+      Bootstrap.ensure_seed_data!()
+      channel = channel_fixture()
+      actor_role = role_fixture(%{permissions: PermissionBits.combine([:moderate_members])})
+      actor = user_fixture(%{email: "timeout-actor@example.com", username: "timeout_actor"})
+      target = user_fixture(%{email: "timeout-target@example.com", username: "timeout_target"})
+      _member_role = member_role_fixture(actor, actor_role)
+
+      assert {:ok, updated_target, moderation_case} =
+               Chat.timeout_member(actor, target, 15, "cool off")
+
+      assert moderation_case.action_type == :timeout
+      assert Chat.timed_out?(updated_target)
+      refute Chat.can_send_messages?(channel, updated_target)
+      refute Chat.can_add_reactions?(channel, updated_target)
+    end
+
+    test "kick_member/3 deactivates membership without banned flag" do
+      Bootstrap.ensure_seed_data!()
+      actor_role = role_fixture(%{permissions: PermissionBits.combine([:kick_members])})
+      actor = user_fixture(%{email: "kick-actor@example.com", username: "kick_actor"})
+      target = user_fixture(%{email: "kick-target@example.com", username: "kick_target"})
+      _member_role = member_role_fixture(actor, actor_role)
+
+      assert {:ok, updated_target, moderation_case} = Chat.kick_member(actor, target, "bye")
+
+      assert moderation_case.action_type == :kick
+      assert updated_target.membership.deactivated_at
+      refute Map.get(updated_target.membership.flags || %{}, "banned")
+    end
+
+    test "ban_member/3 marks banned membership" do
+      Bootstrap.ensure_seed_data!()
+      actor_role = role_fixture(%{permissions: PermissionBits.combine([:ban_members])})
+      actor = user_fixture(%{email: "ban-actor@example.com", username: "ban_actor"})
+      target = user_fixture(%{email: "ban-target@example.com", username: "ban_target"})
+      _member_role = member_role_fixture(actor, actor_role)
+
+      assert {:ok, updated_target, moderation_case} =
+               Chat.ban_member(actor, target, "serious abuse")
+
+      assert moderation_case.action_type == :ban
+      assert updated_target.membership.deactivated_at
+      assert Map.get(updated_target.membership.flags || %{}, "banned")
+      assert Map.get(updated_target.membership.flags || %{}, "ban_reason") == "serious abuse"
+    end
+
     test "delete_message/2 allows moderators with manage_messages" do
       Bootstrap.ensure_seed_data!()
       channel = channel_fixture()

--- a/test/rfchat/chat_test.exs
+++ b/test/rfchat/chat_test.exs
@@ -311,6 +311,36 @@ defmodule Rfchat.ChatTest do
       refute Chat.can_add_reactions?(channel, user)
     end
 
+    test "toggle_reaction/3 supports custom emoji reactions" do
+      Bootstrap.ensure_seed_data!()
+      channel = channel_fixture()
+
+      author =
+        user_fixture(%{email: "emoji-react-author@example.com", username: "emoji_react_author"})
+
+      user = user_fixture(%{email: "emoji-react-user@example.com", username: "emoji_react_user"})
+      message = message_fixture(channel, author)
+      emoji = emoji_fixture(author, %{name: "blobwave", shortcode: ":blobwave:"})
+
+      assert {:ok, updated_message} =
+               Chat.toggle_reaction(message, user, %{"emoji_id" => emoji.id})
+
+      assert Enum.any?(updated_message.reactions, &(&1.emoji_id == emoji.id))
+
+      assert {:ok, updated_message} =
+               Chat.toggle_reaction(message, user, %{"emoji_id" => emoji.id})
+
+      refute Enum.any?(updated_message.reactions, &(&1.emoji_id == emoji.id))
+    end
+
+    test "list_available_emojis/1 includes listed emoji" do
+      Bootstrap.ensure_seed_data!()
+      user = user_fixture(%{email: "emoji-list-user@example.com", username: "emoji_list_user"})
+      emoji = emoji_fixture(user, %{name: "partyblob", shortcode: ":partyblob:"})
+
+      assert Enum.any?(Chat.list_available_emojis(user), &(&1.id == emoji.id))
+    end
+
     test "delete_message/2 allows moderators with manage_messages" do
       Bootstrap.ensure_seed_data!()
       channel = channel_fixture()

--- a/test/rfchat_web/live/guild_live_test.exs
+++ b/test/rfchat_web/live/guild_live_test.exs
@@ -714,6 +714,95 @@ defmodule RfchatWeb.GuildLiveTest do
     refute Enum.any?(Chat.list_custom_emojis(), &(&1.id == emoji.id))
   end
 
+  test "moderators can timeout members from the member sidebar", %{conn: conn} do
+    Bootstrap.ensure_seed_data!()
+
+    moderator_role =
+      role_fixture(%{
+        name: "Timeout Mod",
+        permissions: PermissionBits.combine([:moderate_members])
+      })
+
+    moderator =
+      user_fixture(%{
+        email: "timeout-mod@example.com",
+        username: "timeout_mod",
+        display_name: "Timeout Mod"
+      })
+
+    target =
+      user_fixture(%{
+        email: "timed-target@example.com",
+        username: "timed_target",
+        display_name: "Timed Target"
+      })
+
+    _member_role = member_role_fixture(moderator, moderator_role)
+    token = Rfchat.Accounts.generate_user_session_token(moderator)
+
+    conn =
+      conn
+      |> Phoenix.ConnTest.init_test_session(%{})
+      |> Plug.Conn.put_session(:user_token, token)
+      |> Plug.Conn.put_session(:live_socket_id, "users_sessions:timeout-mod")
+
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    view |> element("#open-member-actions-#{target.id}") |> render_click()
+
+    view
+    |> form("#member-action-form-#{target.id}", %{
+      moderation: %{duration_minutes: 30, reason: "cool off"}
+    })
+    |> render_submit()
+
+    assert has_element?(view, "#member-actions-#{target.id}")
+    assert render(view) =~ "timed out until"
+  end
+
+  test "moderators can ban members from the member sidebar", %{conn: conn} do
+    Bootstrap.ensure_seed_data!()
+
+    moderator_role =
+      role_fixture(%{
+        name: "Ban Mod",
+        permissions: PermissionBits.combine([:ban_members])
+      })
+
+    moderator =
+      user_fixture(%{
+        email: "ban-mod@example.com",
+        username: "ban_mod",
+        display_name: "Ban Mod"
+      })
+
+    target =
+      user_fixture(%{
+        email: "banned-target@example.com",
+        username: "banned_target",
+        display_name: "Banned Target"
+      })
+
+    _member_role = member_role_fixture(moderator, moderator_role)
+    token = Rfchat.Accounts.generate_user_session_token(moderator)
+
+    conn =
+      conn
+      |> Phoenix.ConnTest.init_test_session(%{})
+      |> Plug.Conn.put_session(:user_token, token)
+      |> Plug.Conn.put_session(:live_socket_id, "users_sessions:ban-mod")
+
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    view |> element("#open-member-actions-#{target.id}") |> render_click()
+
+    view
+    |> form("#member-action-form-#{target.id}", %{moderation: %{reason: "repeat abuse"}})
+    |> render_submit()
+
+    assert render(view) =~ "banned"
+  end
+
   defp log_in_member_user(conn, suffix \\ "default") do
     _owner =
       user_fixture(%{

--- a/test/rfchat_web/live/guild_live_test.exs
+++ b/test/rfchat_web/live/guild_live_test.exs
@@ -422,13 +422,14 @@ defmodule RfchatWeb.GuildLiveTest do
     message = Chat.list_messages(Chat.get_channel_by_slug!("general").id) |> List.first()
     reaction_id = Base.url_encode64("👍", padding: false)
 
-    view |> element("#reaction-#{message.id}-#{reaction_id}") |> render_click()
+    view |> element("#open-reaction-picker-#{message.id}") |> render_click()
+    view |> element("#reaction-picker-default-#{message.id}-#{reaction_id}") |> render_click()
 
     assert has_element?(view, "#reaction-#{message.id}-#{reaction_id}", "1")
 
     view |> element("#reaction-#{message.id}-#{reaction_id}") |> render_click()
 
-    assert has_element?(view, "#reaction-#{message.id}-#{reaction_id}", "0")
+    refute has_element?(view, "#reaction-#{message.id}-#{reaction_id}")
   end
 
   test "shows reaction disabled state when add reactions is denied", %{conn: conn} do
@@ -444,15 +445,56 @@ defmodule RfchatWeb.GuildLiveTest do
     {:ok, view, _html} = live(conn, ~p"/")
 
     message = Chat.list_messages(channel.id) |> List.first()
-    reaction_id = Base.url_encode64("👍", padding: false)
-
-    assert has_element?(view, "#reaction-#{message.id}-#{reaction_id}[disabled]")
+    assert has_element?(view, "#open-reaction-picker-#{message.id}[disabled]")
 
     assert has_element?(
              view,
              "#message-list",
              "Reactions are disabled for your permissions in this channel."
            )
+  end
+
+  test "picker shows default and custom reactions but no quick chips", %{conn: conn} do
+    Bootstrap.ensure_seed_data!()
+    conn = log_in_member_user(conn, "picker_layout")
+    user = current_user_from_conn(conn)
+    emoji = emoji_fixture(user, %{name: "blobwow", shortcode: ":blobwow:"})
+
+    {:ok, view, _html} = live(conn, ~p"/")
+    message = Chat.list_messages(Chat.get_channel_by_slug!("general").id) |> List.first()
+    quick_reaction_id = Base.url_encode64("👍", padding: false)
+
+    refute has_element?(view, "#reaction-#{message.id}-#{quick_reaction_id}")
+
+    view |> element("#open-reaction-picker-#{message.id}") |> render_click()
+
+    assert has_element?(view, "#reaction-picker-default-#{message.id}-#{quick_reaction_id}")
+    assert render(view) =~ "reaction-picker-search-#{message.id}"
+    assert render(view) =~ "data-reaction-picker-defaults"
+    assert has_element?(view, "#reaction-picker-custom-#{message.id}-#{emoji.id}")
+  end
+
+  test "opens reaction picker and toggles custom emoji reactions", %{conn: conn} do
+    Bootstrap.ensure_seed_data!()
+    conn = log_in_member_user(conn, "custom_emoji")
+    user = current_user_from_conn(conn)
+    emoji = emoji_fixture(user, %{name: "blobparty", shortcode: ":blobparty:"})
+
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    message = Chat.list_messages(Chat.get_channel_by_slug!("general").id) |> List.first()
+
+    refute has_element?(view, "#reaction-picker-#{message.id}")
+
+    view |> element("#open-reaction-picker-#{message.id}") |> render_click()
+
+    assert has_element?(view, "#reaction-picker-#{message.id}")
+    assert has_element?(view, "#reaction-picker-custom-#{message.id}-#{emoji.id}")
+
+    view |> element("#reaction-picker-custom-#{message.id}-#{emoji.id}") |> render_click()
+
+    assert has_element?(view, "#reaction-#{message.id}-custom-#{emoji.id}", "1")
+    refute has_element?(view, "#reaction-picker-#{message.id}")
   end
 
   test "moderators can delete other users messages", %{conn: conn} do
@@ -620,6 +662,58 @@ defmodule RfchatWeb.GuildLiveTest do
     assert has_element?(view, "#open-channel-manager")
   end
 
+  test "emoji managers can upload and delete custom emoji", %{conn: conn} do
+    Bootstrap.ensure_seed_data!()
+
+    manager_role =
+      role_fixture(%{
+        name: "Emoji Manager",
+        permissions: PermissionBits.combine([:manage_emojis_and_stickers])
+      })
+
+    user =
+      user_fixture(%{
+        email: "emoji-manager@example.com",
+        username: "emoji_manager",
+        display_name: "Emoji Manager"
+      })
+
+    _member_role = member_role_fixture(user, manager_role)
+    token = Rfchat.Accounts.generate_user_session_token(user)
+
+    conn =
+      conn
+      |> Phoenix.ConnTest.init_test_session(%{})
+      |> Plug.Conn.put_session(:user_token, token)
+      |> Plug.Conn.put_session(:live_socket_id, "users_sessions:emoji-manager")
+
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    view |> element("#open-emoji-manager") |> render_click()
+
+    upload =
+      file_input(view, "#emoji-form", :emoji_image, [
+        %{
+          last_modified: 1_711_000_000_000,
+          name: "blob.png",
+          content: "fake png bytes",
+          type: "image/png"
+        }
+      ])
+
+    render_upload(upload, "blob.png")
+
+    view
+    |> form("#emoji-form", %{emoji: %{name: "blobhype", shortcode: ":blobhype:"}})
+    |> render_submit()
+
+    assert has_element?(view, "#manage-emoji-#{List.last(Chat.list_custom_emojis()).id}")
+
+    emoji = List.last(Chat.list_custom_emojis())
+    view |> element("#delete-emoji-#{emoji.id}") |> render_click()
+    refute Enum.any?(Chat.list_custom_emojis(), &(&1.id == emoji.id))
+  end
+
   defp log_in_member_user(conn, suffix \\ "default") do
     _owner =
       user_fixture(%{
@@ -657,6 +751,11 @@ defmodule RfchatWeb.GuildLiveTest do
     |> Phoenix.ConnTest.init_test_session(%{})
     |> Plug.Conn.put_session(:user_token, token)
     |> Plug.Conn.put_session(:live_socket_id, "users_sessions:owner")
+  end
+
+  defp current_user_from_conn(conn) do
+    token = Plug.Conn.get_session(conn, :user_token)
+    Rfchat.Accounts.get_user_by_session_token(token)
   end
 
   defp category_id(slug), do: Chat.get_channel_by_slug!(slug).id

--- a/test/rfchat_web/live/user_auth_live_test.exs
+++ b/test/rfchat_web/live/user_auth_live_test.exs
@@ -133,4 +133,38 @@ defmodule RfchatWeb.UserAuthLiveTest do
     assert html =~ "auth works"
     assert render(view) =~ "Guild User"
   end
+
+  test "banned user login redirects to banned screen", %{conn: conn} do
+    banned_user =
+      user_fixture(%{
+        email: "banned@example.com",
+        username: "banned_user",
+        display_name: "Banned User"
+      })
+
+    banned_user = Rfchat.Accounts.get_user_with_membership!(banned_user.id)
+
+    banned_user.membership
+    |> Rfchat.Chat.Membership.changeset(%{
+      deactivated_at: DateTime.utc_now(),
+      flags: %{"banned" => true, "ban_reason" => "repeat abuse"}
+    })
+    |> Rfchat.Repo.update!()
+
+    {:ok, login_view, _html} = live(conn, ~p"/login")
+
+    login_form =
+      form(login_view, "#login-form", %{
+        user: %{email: "banned@example.com", password: "supersecurepass"}
+      })
+
+    render_submit(login_form)
+
+    conn = follow_trigger_action(login_form, conn)
+
+    assert redirected_to(conn) == ~p"/banned"
+
+    {:ok, banned_view, _html} = live(conn, ~p"/banned")
+    assert render(banned_view) =~ "repeat abuse"
+  end
 end

--- a/test/support/fixtures/chat_fixtures.ex
+++ b/test/support/fixtures/chat_fixtures.ex
@@ -4,7 +4,9 @@ defmodule Rfchat.ChatFixtures do
   alias Rfchat.Accounts
   alias Rfchat.Chat
   alias Rfchat.Chat.ChannelPermissionOverwrite
+  alias Rfchat.Chat.Emoji
   alias Rfchat.Chat.MemberRole
+  alias Rfchat.Chat.MediaAsset
   alias Rfchat.Chat.Reaction
   alias Rfchat.Chat.Role
   alias Rfchat.Repo
@@ -89,5 +91,52 @@ defmodule Rfchat.ChatFixtures do
       |> Repo.insert()
 
     reaction
+  end
+
+  def media_asset_fixture(user, attrs \\ %{}) do
+    attrs =
+      Enum.into(attrs, %{
+        uploader_id: user.id,
+        kind: :emoji,
+        storage_provider: "local",
+        storage_key: "uploads/emojis/test-#{System.unique_integer([:positive])}.png",
+        original_filename: "emoji.png",
+        content_type: "image/png",
+        byte_size: 128,
+        sha256: String.duplicate("a", 64)
+      })
+
+    {:ok, asset} =
+      %MediaAsset{}
+      |> MediaAsset.changeset(attrs)
+      |> Repo.insert()
+
+    asset
+  end
+
+  def emoji_fixture(user, attrs \\ %{}) do
+    asset = Map.get(attrs, :asset) || Map.get(attrs, "asset") || media_asset_fixture(user)
+
+    attrs =
+      attrs
+      |> Map.new(fn
+        {key, value} when is_atom(key) -> {Atom.to_string(key), value}
+        pair -> pair
+      end)
+      |> Map.drop(["asset"])
+      |> Enum.into(%{
+        "name" => "blob_#{System.unique_integer([:positive])}",
+        "shortcode" => ":blob_#{System.unique_integer([:positive])}:",
+        "asset_id" => asset.id,
+        "available" => true,
+        "listed" => true
+      })
+
+    {:ok, emoji} =
+      %Emoji{creator_id: user.id}
+      |> Emoji.changeset(attrs)
+      |> Repo.insert()
+
+    Repo.preload(emoji, [:asset, :emoji_roles])
   end
 end


### PR DESCRIPTION
## Summary
- add timeout, kick, and ban moderation actions with moderation case + audit log persistence
- add member-sidebar moderation controls and enforce timeout on sending/reactions
- route banned users to a dedicated banned landing screen instead of hard auth rejection

## Testing
- mix test test/rfchat/chat_test.exs test/rfchat_web/live/user_auth_live_test.exs test/rfchat_web/live/guild_live_test.exs
- mix precommit